### PR TITLE
SSR support & scope nesting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
-  "arrowParens": "always",
+  "trailingComma": "all",
   "singleQuote": true,
-  "trailingComma": "all"
+  "arrowParens": "always",
+  "printWidth": 120
 }

--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@ Use this to setup your services/tokens/factories/... that will later be injected
 - A factory (method that will be called)
 
 ```typescript
-function DefineModule(providers: Array<TProvider>, scope?: object): void;
+function DefineModule(providers: Array<TProvider>, scope?: ScopeToken | string): void;
 ```
 
 ```typescript
@@ -41,7 +41,7 @@ DefineModule([
 When testing your code that depends on something (e.g. `DataService`) you can't use `DefineModule` since it's a global thing. Use `GenerateTestBead` in a `beforeEach` hook.
 
 ```typescript
-function GenerateTestBed(providers: Array<TProvider>, scope?: object): void;
+function GenerateTestBed(providers: Array<TProvider>, scope?: ScopeToken | string): void;
 ```
 
 ```typescript
@@ -95,7 +95,7 @@ DefineModule([
 Use this for injecting stuff in non-react code.
 
 ```typescript
-function inject<T>(cls: IConstructor<T> | InjectionToken<T>, scope?: object): T;
+function inject<T>(cls: IConstructor<T> | InjectionToken<T>, scope?: ScopeToken): T;
 ```
 
 ```typescript
@@ -115,7 +115,7 @@ DefineModule([SomeService, DataService]);
 ### useInject
 
 ```typescript
-function useInject<T>(cls: IConstructor<T> | InjectionToken<T>, scope?: object): T;
+function useInject<T>(cls: IConstructor<T> | InjectionToken<T>, scope?: ScopeToken): T;
 ```
 
 ## Scope & SSR support
@@ -127,7 +127,7 @@ The scope will be passed to the class as the constructor argument or to a factor
 ### useContextInject
 
 ```typescript
-function useContextInject<T>(cls: TKey<T>, contextKey: Context<object>): T;
+function useContextInject<T>(cls: TKey<T>, contextKey: Context<ScopeToken>): T;
 ```
 
 To make things simpler with React, the most likely case is to pass the scope through the React context. To avoid two operations (`useContext` to get the scope, and then `useInject`), there is one more react hook called `useContextInject`.

--- a/Readme.md
+++ b/Readme.md
@@ -18,8 +18,10 @@ Use this to setup your services/tokens/factories/... that will later be injected
 - A value (e.g. `window`)
 - A factory (method that will be called)
 
+You can also define a parent scope to enable scope nesting.
+
 ```typescript
-function DefineModule(providers: Array<TProvider>, scope?: ScopeToken | string): void;
+function DefineModule(providers: Array<TProvider>, scope?: ScopeToken | string, parentScope?: ScopeToken): ScopeToken;
 ```
 
 ```typescript
@@ -41,7 +43,7 @@ DefineModule([
 When testing your code that depends on something (e.g. `DataService`) you can't use `DefineModule` since it's a global thing. Use `GenerateTestBead` in a `beforeEach` hook.
 
 ```typescript
-function GenerateTestBed(providers: Array<TProvider>, scope?: ScopeToken | string): void;
+function GenerateTestBed(providers: Array<TProvider>, scope?: ScopeToken | string, parentScope?: ScopeToken): ScopeToken;
 ```
 
 ```typescript

--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@ Use this to setup your services/tokens/factories/... that will later be injected
 - A factory (method that will be called)
 
 ```typescript
-function DefineModule(providers: Array<TProvider>): void;
+function DefineModule(providers: Array<TProvider>, scope?: object): void;
 ```
 
 ```typescript
@@ -41,7 +41,7 @@ DefineModule([
 When testing your code that depends on something (e.g. `DataService`) you can't use `DefineModule` since it's a global thing. Use `GenerateTestBead` in a `beforeEach` hook.
 
 ```typescript
-function GenerateTestBed(providers: Array<TProvider>): void;
+function GenerateTestBed(providers: Array<TProvider>, scope?: object): void;
 ```
 
 ```typescript
@@ -95,7 +95,7 @@ DefineModule([
 Use this for injecting stuff in non-react code.
 
 ```typescript
-function inject<T>(cls: IConstructor<T> | InjectionToken<T>): T;
+function inject<T>(cls: IConstructor<T> | InjectionToken<T>, scope?: object): T;
 ```
 
 ```typescript
@@ -115,8 +115,22 @@ DefineModule([SomeService, DataService]);
 ### useInject
 
 ```typescript
-function useInject<T>(cls: IConstructor<T> | InjectionToken<T>): T;
+function useInject<T>(cls: IConstructor<T> | InjectionToken<T>, scope?: object): T;
 ```
+
+## Scope & SSR support
+
+In order to support Server-side rendering and other use cases that require multiple scopes, there is a possibility to define a specific scope.
+
+The scope will be passed to the class as the constructor argument or to a factory as a function argument. That way the class or factory can pass it to inject if they need it.
+
+### useContextInject
+
+```typescript
+function useContextInject<T>(cls: TKey<T>, contextKey: Context<object>): T;
+```
+
+To make things simpler with React, the most likely case is to pass the scope through the React context. To avoid two operations (`useContext` to get the scope, and then `useInject`), there is one more react hook called `useContextInject`.
 
 TODO
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4045,6 +4045,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
+      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "24.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^16.8.14",
     "husky": "^1.3.1",
     "jest": "^24.7.1",
+    "prettier": "^1.17.0",
     "react": "^16.8.6",
     "rollup": "^1.10.1",
     "rollup-plugin-typescript2": "^0.20.1",
@@ -23,13 +24,14 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm test"
+      "pre-commit": "npm run lint && npm test"
     }
   },
   "scripts": {
     "test": "jest",
     "build": "rollup -c",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "lint": "prettier --check **/*.{ts,tsx} !dist/**"
   },
   "repository": {
     "type": "git",

--- a/src/ScopeToken.ts
+++ b/src/ScopeToken.ts
@@ -1,0 +1,11 @@
+export class ScopeToken {
+  private key: String;
+
+  constructor(key: string = '') {
+    this.key = new String(key);
+  }
+
+  public toString() {
+    return `ScopeToken(${this.key})`;
+  }
+}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_SCOPE = {};

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,3 +1,5 @@
 import { ScopeToken } from './ScopeToken';
+import { InjectionToken } from './InjectionToken';
 
 export const DEFAULT_SCOPE = new ScopeToken('DEFAULT_SCOPE');
+export const PARENT_SCOPE_KEY = new InjectionToken<ScopeToken>('PARENT_SCOPE');

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,1 +1,3 @@
-export const DEFAULT_SCOPE = {};
+import { ScopeToken } from './ScopeToken';
+
+export const DEFAULT_SCOPE = new ScopeToken('DEFAULT_SCOPE');

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -11,7 +11,9 @@ export function useInject<T>(cls: TKey<T>, scope: ScopeToken = DEFAULT_SCOPE): T
 }
 
 export function useContextInject<T>(cls: TKey<T>, contextKey: Context<ScopeToken>): T {
+  /* istanbul ignore next */
   const scope = useContext(contextKey);
+  /* istanbul ignore next */
   return useInject(cls, scope);
 }
 

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -1,6 +1,6 @@
 import { Context, useContext, useMemo } from 'react';
 
-import { DEFAULT_SCOPE } from './consts';
+import { DEFAULT_SCOPE, PARENT_SCOPE_KEY } from './consts';
 import { mappings } from './mappings';
 import { ScopeToken } from './ScopeToken';
 import { TKey } from './types';
@@ -24,6 +24,9 @@ export function inject<T>(cls: TKey<T>, scope: ScopeToken = DEFAULT_SCOPE): T {
   const isInitialized = map.has(cls);
 
   if (!isInitialized) {
+    if (map.has(PARENT_SCOPE_KEY)) {
+      return inject(cls, map.get(PARENT_SCOPE_KEY));
+    }
     throw new Error('Injectables have to be provided in a module.');
   }
 

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -1,19 +1,25 @@
 import { useMemo } from 'react';
 
+import { DEFAULT_SCOPE } from './consts';
 import { mappings } from './mappings';
 import { TKey } from './types';
 
-export function useInject<T>(cls: TKey<T>): T {
+export function useInject<T>(cls: TKey<T>, scope: object = DEFAULT_SCOPE): T {
   /* istanbul ignore next */
-  return useMemo<T>(() => inject(cls), [cls]);
+  return useMemo<T>(() => inject(cls, scope), [cls]);
 }
 
-export function inject<T>(cls: TKey<T>): T {
-  const isInitialized = mappings.has(cls);
+export function inject<T>(cls: TKey<T>, scope: object = DEFAULT_SCOPE): T {
+  const map = mappings.get(scope);
+  if (!map) {
+    throw new Error('The given scope is not defined');
+  }
+
+  const isInitialized = map.has(cls);
 
   if (!isInitialized) {
     throw new Error('Injectables have to be provided in a module.');
   }
 
-  return mappings.get(cls) as T;
+  return map.get(cls) as T;
 }

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -1,15 +1,21 @@
-import { useMemo } from 'react';
+import { Context, useContext, useMemo } from 'react';
 
 import { DEFAULT_SCOPE } from './consts';
 import { mappings } from './mappings';
+import { ScopeToken } from './ScopeToken';
 import { TKey } from './types';
 
-export function useInject<T>(cls: TKey<T>, scope: object = DEFAULT_SCOPE): T {
+export function useInject<T>(cls: TKey<T>, scope: ScopeToken = DEFAULT_SCOPE): T {
   /* istanbul ignore next */
-  return useMemo<T>(() => inject(cls, scope), [cls]);
+  return useMemo<T>(() => inject(cls, scope), [cls, scope]);
 }
 
-export function inject<T>(cls: TKey<T>, scope: object = DEFAULT_SCOPE): T {
+export function useContextInject<T>(cls: TKey<T>, contextKey: Context<ScopeToken>): T {
+  const scope = useContext(contextKey);
+  return useInject(cls, scope);
+}
+
+export function inject<T>(cls: TKey<T>, scope: ScopeToken = DEFAULT_SCOPE): T {
   const map = mappings.get(scope);
   if (!map) {
     throw new Error('The given scope is not defined');

--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -1,3 +1,4 @@
+import { ScopeToken } from './ScopeToken';
 import { TKey } from './types';
 
 export class DependencyMap<T = any> {
@@ -25,4 +26,4 @@ export class DependencyMap<T = any> {
   }
 }
 
-export const mappings = new WeakMap<any, DependencyMap>();
+export const mappings = new WeakMap<ScopeToken, DependencyMap>();

--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -4,11 +4,7 @@ import { TKey } from './types';
 export class DependencyMap<T = any> {
   private _wm: WeakMap<TKey<T>, T>;
 
-  constructor(init: Iterable<any> = []) {
-    this._wm = new WeakMap(init);
-  }
-
-  public clear() {
+  constructor() {
     this._wm = new WeakMap();
   }
 

--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -1,9 +1,9 @@
 import { TKey } from './types';
 
-class ClearableWeakMap<T = any> {
+export class DependencyMap<T = any> {
   private _wm: WeakMap<TKey<T>, T>;
 
-  constructor(init: Iterable<any>) {
+  constructor(init: Iterable<any> = []) {
     this._wm = new WeakMap(init);
   }
 
@@ -25,4 +25,4 @@ class ClearableWeakMap<T = any> {
   }
 }
 
-export const mappings = new ClearableWeakMap([]);
+export const mappings = new WeakMap<any, DependencyMap>();

--- a/src/module.ts
+++ b/src/module.ts
@@ -11,6 +11,7 @@ export function DefineModule(providers: Array<TProvider>, scope: ScopeToken | st
   }
   const map = mappings.get(scopeToken);
   if (!map) {
+    /* istanbul ignore next */
     throw new Error('Something went wrong - Dependency map couldn\'t be generated');
   }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,22 +1,31 @@
-import { mappings } from './mappings';
+import { DEFAULT_SCOPE } from './consts';
+import { mappings, DependencyMap } from './mappings';
 import { TProvider } from './types';
 import { preprocessProvider } from './utils';
 
-export function DefineModule(providers: Array<TProvider>): void {
+export function DefineModule(providers: Array<TProvider>, scope: object = DEFAULT_SCOPE): void {
+  if (!mappings.has(scope)) {
+    mappings.set(scope, new DependencyMap());
+  }
+  const map = mappings.get(scope);
+  if (!map) {
+    throw new Error('Something went wrong - Dependency map couldn\'t be generated');
+  }
+
   for (const provider of providers) {
     const prov = preprocessProvider(provider);
     const providerToken = prov.provider;
     if ('initClass' in prov) {
-      mappings.set(providerToken, new prov.initClass());
+      map.set(providerToken, new prov.initClass(scope));
     } else if ('initValue' in prov) {
-      mappings.set(providerToken, prov.initValue);
+      map.set(providerToken, prov.initValue);
     } else if ('initFactory' in prov) {
-      mappings.set(providerToken, prov.initFactory());
+      map.set(providerToken, prov.initFactory(scope));
     }
   }
 }
 
-export function GenerateTestBed(providers: Array<TProvider>): void {
-  mappings.clear();
-  return DefineModule(providers);
+export function GenerateTestBed(providers: Array<TProvider>, scope: object = DEFAULT_SCOPE): void {
+  mappings.set(scope, new DependencyMap());
+  return DefineModule(providers, scope);
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,10 +1,10 @@
-import { DEFAULT_SCOPE } from './consts';
+import { DEFAULT_SCOPE, PARENT_SCOPE_KEY } from './consts';
 import { mappings, DependencyMap } from './mappings';
 import { ScopeToken } from './ScopeToken';
 import { TProvider } from './types';
 import { preprocessProvider } from './utils';
 
-export function DefineModule(providers: Array<TProvider>, scope: ScopeToken | string = DEFAULT_SCOPE): ScopeToken {
+export function DefineModule(providers: Array<TProvider>, scope: ScopeToken | string = DEFAULT_SCOPE, parentScope?: ScopeToken): ScopeToken {
   const scopeToken = scope instanceof ScopeToken ? scope : new ScopeToken(scope);
   if (!mappings.has(scopeToken)) {
     mappings.set(scopeToken, new DependencyMap());
@@ -12,6 +12,10 @@ export function DefineModule(providers: Array<TProvider>, scope: ScopeToken | st
   const map = mappings.get(scopeToken);
   if (!map) {
     throw new Error('Something went wrong - Dependency map couldn\'t be generated');
+  }
+
+  if (parentScope) {
+    map.set(PARENT_SCOPE_KEY, parentScope);
   }
 
   for (const provider of providers) {
@@ -29,8 +33,8 @@ export function DefineModule(providers: Array<TProvider>, scope: ScopeToken | st
   return scopeToken;
 }
 
-export function GenerateTestBed(providers: Array<TProvider>, scope: ScopeToken | string = DEFAULT_SCOPE): ScopeToken {
+export function GenerateTestBed(providers: Array<TProvider>, scope: ScopeToken | string = DEFAULT_SCOPE, parentScope?: ScopeToken): ScopeToken {
   const scopeToken = scope instanceof ScopeToken ? scope : new ScopeToken(scope);
   mappings.set(scopeToken, new DependencyMap());
-  return DefineModule(providers, scopeToken);
+  return DefineModule(providers, scopeToken, parentScope);
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,13 +1,15 @@
 import { DEFAULT_SCOPE } from './consts';
 import { mappings, DependencyMap } from './mappings';
+import { ScopeToken } from './ScopeToken';
 import { TProvider } from './types';
 import { preprocessProvider } from './utils';
 
-export function DefineModule(providers: Array<TProvider>, scope: object = DEFAULT_SCOPE): void {
-  if (!mappings.has(scope)) {
-    mappings.set(scope, new DependencyMap());
+export function DefineModule(providers: Array<TProvider>, scope: ScopeToken | string = DEFAULT_SCOPE): ScopeToken {
+  const scopeToken = scope instanceof ScopeToken ? scope : new ScopeToken(scope);
+  if (!mappings.has(scopeToken)) {
+    mappings.set(scopeToken, new DependencyMap());
   }
-  const map = mappings.get(scope);
+  const map = mappings.get(scopeToken);
   if (!map) {
     throw new Error('Something went wrong - Dependency map couldn\'t be generated');
   }
@@ -16,16 +18,19 @@ export function DefineModule(providers: Array<TProvider>, scope: object = DEFAUL
     const prov = preprocessProvider(provider);
     const providerToken = prov.provider;
     if ('initClass' in prov) {
-      map.set(providerToken, new prov.initClass(scope));
+      map.set(providerToken, new prov.initClass(scopeToken));
     } else if ('initValue' in prov) {
       map.set(providerToken, prov.initValue);
     } else if ('initFactory' in prov) {
-      map.set(providerToken, prov.initFactory(scope));
+      map.set(providerToken, prov.initFactory(scopeToken));
     }
   }
+
+  return scopeToken;
 }
 
-export function GenerateTestBed(providers: Array<TProvider>, scope: object = DEFAULT_SCOPE): void {
-  mappings.set(scope, new DependencyMap());
-  return DefineModule(providers, scope);
+export function GenerateTestBed(providers: Array<TProvider>, scope: ScopeToken | string = DEFAULT_SCOPE): ScopeToken {
+  const scopeToken = scope instanceof ScopeToken ? scope : new ScopeToken(scope);
+  mappings.set(scopeToken, new DependencyMap());
+  return DefineModule(providers, scopeToken);
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,7 +4,11 @@ import { ScopeToken } from './ScopeToken';
 import { TProvider } from './types';
 import { preprocessProvider } from './utils';
 
-export function DefineModule(providers: Array<TProvider>, scope: ScopeToken | string = DEFAULT_SCOPE, parentScope?: ScopeToken): ScopeToken {
+export function DefineModule(
+  providers: Array<TProvider>,
+  scope: ScopeToken | string = DEFAULT_SCOPE,
+  parentScope?: ScopeToken,
+): ScopeToken {
   const scopeToken = scope instanceof ScopeToken ? scope : new ScopeToken(scope);
   if (!mappings.has(scopeToken)) {
     mappings.set(scopeToken, new DependencyMap());
@@ -12,10 +16,13 @@ export function DefineModule(providers: Array<TProvider>, scope: ScopeToken | st
   const map = mappings.get(scopeToken);
   if (!map) {
     /* istanbul ignore next */
-    throw new Error('Something went wrong - Dependency map couldn\'t be generated');
+    throw new Error("Something went wrong - Dependency map couldn't be generated");
   }
 
   if (parentScope) {
+    if (map.has(PARENT_SCOPE_KEY)) {
+      throw new Error("Parent scope can't be redefined");
+    }
     map.set(PARENT_SCOPE_KEY, parentScope);
   }
 
@@ -34,7 +41,11 @@ export function DefineModule(providers: Array<TProvider>, scope: ScopeToken | st
   return scopeToken;
 }
 
-export function GenerateTestBed(providers: Array<TProvider>, scope: ScopeToken | string = DEFAULT_SCOPE, parentScope?: ScopeToken): ScopeToken {
+export function GenerateTestBed(
+  providers: Array<TProvider>,
+  scope: ScopeToken | string = DEFAULT_SCOPE,
+  parentScope?: ScopeToken,
+): ScopeToken {
   const scopeToken = scope instanceof ScopeToken ? scope : new ScopeToken(scope);
   mappings.set(scopeToken, new DependencyMap());
   return DefineModule(providers, scopeToken, parentScope);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { InjectionToken } from './InjectionToken';
+import { ScopeToken } from './ScopeToken';
 
-export type IConstructor<T = any> = new (scope?: object) => T;
+export type IConstructor<T = any> = new (scope?: ScopeToken) => T;
 export type TKey<T = any> = InjectionToken<T> | IConstructor<T>;
 
 export type TComplexProvider<T = any> =
@@ -10,7 +11,7 @@ export type TComplexProvider<T = any> =
   }
   | {
     provider: TKey<T>;
-    initFactory(scope?: object): T;
+    initFactory(scope?: ScopeToken): T;
   }
   | {
     provider: TKey<T>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { InjectionToken } from './InjectionToken';
 
-export type IConstructor<T = any> = new () => T;
+export type IConstructor<T = any> = new (scope?: object) => T;
 export type TKey<T = any> = InjectionToken<T> | IConstructor<T>;
 
 export type TComplexProvider<T = any> =
@@ -10,7 +10,7 @@ export type TComplexProvider<T = any> =
   }
   | {
     provider: TKey<T>;
-    initFactory(): T;
+    initFactory(scope?: object): T;
   }
   | {
     provider: TKey<T>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,16 +6,16 @@ export type TKey<T = any> = InjectionToken<T> | IConstructor<T>;
 
 export type TComplexProvider<T = any> =
   | {
-    provider: TKey<T>;
-    initValue: T;
-  }
+      provider: TKey<T>;
+      initValue: T;
+    }
   | {
-    provider: TKey<T>;
-    initFactory(scope?: ScopeToken): T;
-  }
+      provider: TKey<T>;
+      initFactory(scope?: ScopeToken): T;
+    }
   | {
-    provider: TKey<T>;
-    initClass: IConstructor<T>;
-  };
+      provider: TKey<T>;
+      initClass: IConstructor<T>;
+    };
 
 export type TProvider<T = any> = IConstructor<T> | TComplexProvider<T>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,16 +3,10 @@ import { IConstructor, TComplexProvider, TProvider } from './types';
 function isSingleProvider<T>(provider: IConstructor<T>): true;
 function isSingleProvider<T>(provider: TComplexProvider<T>): false;
 function isSingleProvider<T>(provider: TProvider<T>): boolean {
-  return (
-    !('initValue' in provider) &&
-    !('initFactory' in provider) &&
-    !('initClass' in provider)
-  );
+  return !('initValue' in provider) && !('initFactory' in provider) && !('initClass' in provider);
 }
 
-export function preprocessProvider<T = any>(
-  provider: TProvider<T>,
-): TComplexProvider<T> {
+export function preprocessProvider<T = any>(provider: TProvider<T>): TComplexProvider<T> {
   if (isSingleProvider<T>(provider as IConstructor)) {
     return {
       initClass: provider as IConstructor<T>,

--- a/test/test.ts
+++ b/test/test.ts
@@ -96,3 +96,43 @@ it('should be able to name InjectionToken', () => {
   expect(value).toBe(tokenValue);
   expect(TOKEN.toString()).toBe(`InjectionToken(${tokenValue})`);
 });
+
+it('Should work with multiple scopes', () => {
+  const SCOPE_A = {};
+  const SCOPE_B = {};
+  const TOKEN = new InjectionToken<string>();
+
+  class ProxyClass {
+    public service = inject(TOKEN, this.scope);
+
+    constructor(private scope?: object) { }
+  }
+
+  DefineModule([
+    {
+      initValue: 'A',
+      provider: TOKEN,
+    },
+    ProxyClass,
+  ], SCOPE_A);
+
+  DefineModule([
+    {
+      initValue: 'B',
+      provider: TOKEN,
+    },
+    ProxyClass,
+  ], SCOPE_B);
+
+  DefineModule([
+    {
+      initValue: 'C',
+      provider: TOKEN,
+    },
+    ProxyClass,
+  ]);
+
+  expect(inject(ProxyClass, SCOPE_A).service).toBe('A');
+  expect(inject(ProxyClass, SCOPE_B).service).toBe('B');
+  expect(inject(ProxyClass).service).toBe('C');
+});

--- a/test/test.ts
+++ b/test/test.ts
@@ -4,6 +4,7 @@ import {
   InjectionToken,
   GenerateTestBed,
 } from '../src/index';
+import { ScopeToken } from '../src/ScopeToken';
 
 it('should be able to define and inject a class module', () => {
   class FakeClass {}
@@ -98,14 +99,13 @@ it('should be able to name InjectionToken', () => {
 });
 
 it('Should work with multiple scopes', () => {
-  const SCOPE_A = {};
-  const SCOPE_B = {};
+  const SCOPE_A = new ScopeToken('A');
   const TOKEN = new InjectionToken<string>();
 
   class ProxyClass {
     public service = inject(TOKEN, this.scope);
 
-    constructor(private scope?: object) { }
+    constructor(private scope?: ScopeToken) { }
   }
 
   DefineModule([
@@ -116,13 +116,13 @@ it('Should work with multiple scopes', () => {
     ProxyClass,
   ], SCOPE_A);
 
-  DefineModule([
+  const SCOPE_B = DefineModule([
     {
       initValue: 'B',
       provider: TOKEN,
     },
     ProxyClass,
-  ], SCOPE_B);
+  ], 'B');
 
   DefineModule([
     {

--- a/test/test.ts
+++ b/test/test.ts
@@ -98,6 +98,12 @@ it('should be able to name InjectionToken', () => {
   expect(TOKEN.toString()).toBe(`InjectionToken(${tokenValue})`);
 });
 
+it('should be able to name ScopeToken', () => {
+  const tokenValue = '123';
+  const TOKEN = new ScopeToken(tokenValue);
+  expect(TOKEN.toString()).toBe(`ScopeToken(${tokenValue})`);
+});
+
 it('Should work with multiple scopes', () => {
   const SCOPE_A = new ScopeToken('A');
   const TOKEN = new InjectionToken<string>();
@@ -135,6 +141,20 @@ it('Should work with multiple scopes', () => {
   expect(inject(ProxyClass, SCOPE_A).service).toBe('A');
   expect(inject(ProxyClass, SCOPE_B).service).toBe('B');
   expect(inject(ProxyClass).service).toBe('C');
+});
+
+it('Should throw if the scope is not defined', () => {
+  const UNDEFINED_SCOPE = new ScopeToken();
+  const TOKEN = new InjectionToken<string>();
+
+  DefineModule([
+    {
+      initValue: 'C',
+      provider: TOKEN,
+    }
+  ]);
+
+  expect(() => inject(TOKEN, UNDEFINED_SCOPE)).toThrow();
 });
 
 it('Should work with multiple scopes', () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,9 +1,4 @@
-import {
-  DefineModule,
-  inject,
-  InjectionToken,
-  GenerateTestBed,
-} from '../src/index';
+import { DefineModule, inject, InjectionToken, GenerateTestBed } from '../src/index';
 import { ScopeToken } from '../src/ScopeToken';
 
 it('should be able to define and inject a class module', () => {
@@ -59,9 +54,7 @@ it('should throw if nothing was provided', () => {
   class FakeClass {}
   GenerateTestBed([]);
 
-  expect(() => inject(FakeClass)).toThrowError(
-    'Injectables have to be provided in a module.',
-  );
+  expect(() => inject(FakeClass)).toThrowError('Injectables have to be provided in a module.');
 });
 
 it('should clear the mappings with TestBed', () => {
@@ -73,9 +66,7 @@ it('should clear the mappings with TestBed', () => {
 
   GenerateTestBed([]);
 
-  expect(() => inject(FakeClass)).toThrowError(
-    'Injectables have to be provided in a module.',
-  );
+  expect(() => inject(FakeClass)).toThrowError('Injectables have to be provided in a module.');
 });
 
 it('should be able to name InjectionToken', () => {
@@ -111,24 +102,30 @@ it('Should work with multiple scopes', () => {
   class ProxyClass {
     public service = inject(TOKEN, this.scope);
 
-    constructor(private scope?: ScopeToken) { }
+    constructor(private scope?: ScopeToken) {}
   }
 
-  DefineModule([
-    {
-      initValue: 'A',
-      provider: TOKEN,
-    },
-    ProxyClass,
-  ], SCOPE_A);
+  DefineModule(
+    [
+      {
+        initValue: 'A',
+        provider: TOKEN,
+      },
+      ProxyClass,
+    ],
+    SCOPE_A,
+  );
 
-  const SCOPE_B = DefineModule([
-    {
-      initValue: 'B',
-      provider: TOKEN,
-    },
-    ProxyClass,
-  ], 'B');
+  const SCOPE_B = DefineModule(
+    [
+      {
+        initValue: 'B',
+        provider: TOKEN,
+      },
+      ProxyClass,
+    ],
+    'B',
+  );
 
   DefineModule([
     {
@@ -151,7 +148,7 @@ it('Should throw if the scope is not defined', () => {
     {
       initValue: 'C',
       provider: TOKEN,
-    }
+    },
   ]);
 
   expect(() => inject(TOKEN, UNDEFINED_SCOPE)).toThrow();
@@ -165,31 +162,36 @@ it('Should work with multiple scopes', () => {
   class ProxyClass {
     public service = inject(TOKEN_A, this.scope);
 
-    constructor(private scope?: ScopeToken) { }
+    constructor(private scope?: ScopeToken) {}
   }
 
-  const PARENT = DefineModule([
-    {
-      initValue: 'B',
-      provider: TOKEN_A,
-    },
-    {
-      initValue: 'b',
-      provider: TOKEN_B,
-    }
-  ], 'Parent');
+  const PARENT = DefineModule(
+    [
+      {
+        initValue: 'B',
+        provider: TOKEN_A,
+      },
+      {
+        initValue: 'b',
+        provider: TOKEN_B,
+      },
+    ],
+    'Parent',
+  );
 
-  DefineModule([
-    {
-      initValue: 'A',
-      provider: TOKEN_A,
-    },
-    ProxyClass,
-  ], SCOPE_A, PARENT);
+  DefineModule(
+    [
+      {
+        initValue: 'A',
+        provider: TOKEN_A,
+      },
+      ProxyClass,
+    ],
+    SCOPE_A,
+    PARENT,
+  );
 
-  const SCOPE_B = DefineModule([
-    ProxyClass,
-  ], 'B', PARENT);
+  const SCOPE_B = DefineModule([ProxyClass], 'B', PARENT);
 
   const SCOPE_C = DefineModule([], 'C');
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -136,3 +136,45 @@ it('Should work with multiple scopes', () => {
   expect(inject(ProxyClass, SCOPE_B).service).toBe('B');
   expect(inject(ProxyClass).service).toBe('C');
 });
+
+it('Should work with multiple scopes', () => {
+  const SCOPE_A = new ScopeToken('A');
+  const TOKEN_A = new InjectionToken<string>();
+  const TOKEN_B = new InjectionToken<string>();
+
+  class ProxyClass {
+    public service = inject(TOKEN_A, this.scope);
+
+    constructor(private scope?: ScopeToken) { }
+  }
+
+  const PARENT = DefineModule([
+    {
+      initValue: 'B',
+      provider: TOKEN_A,
+    },
+    {
+      initValue: 'b',
+      provider: TOKEN_B,
+    }
+  ], 'Parent');
+
+  DefineModule([
+    {
+      initValue: 'A',
+      provider: TOKEN_A,
+    },
+    ProxyClass,
+  ], SCOPE_A, PARENT);
+
+  const SCOPE_B = DefineModule([
+    ProxyClass,
+  ], 'B', PARENT);
+
+  const SCOPE_C = DefineModule([], 'C');
+
+  expect(inject(ProxyClass, SCOPE_A).service).toBe('A');
+  expect(inject(ProxyClass, SCOPE_B).service).toBe('B');
+  expect(inject(TOKEN_B, SCOPE_B)).toBe('b');
+  expect(() => inject(TOKEN_B, SCOPE_C)).toThrow();
+});


### PR DESCRIPTION
# SSR support

Introduced the "scope" concept - every dependency belongs to a scope. The scope parameter is optional and will default to a shared scope.
In case of SSR, the scope needs to be known and therefore it should be provided to `inject` and `useInject`. To make things simpler, the `initFactory` and `initClass` will provide the current scope so the services can pass the scope to their injects:

```typescript
const TOKEN = new InjectionToken<number>();

class ExampleServiceClass {
  public service = inject(TOKEN, this.scope);

  constructor(private scope?: ScopeToken) {}
}

const myScope = DefineModule([
  ExampleServiceClass,
  {
    initValue: 123,
    provider: TOKEN,
  }
], 'My new scope');

const exampleService = inject(ExampleServiceClass, myScope); // OK
const exampleService = inject(ExampleServiceClass); // Injectables have to be provided in a module.
```

For React part, the scope can be passed trough context and then retrieved from it. To make it simpler, there is also the `useContextInject` hook.

`DefineModule` and `GenerateTestBed` can receive the scope they should use (as the 2nd argument), but they can also create a new one if the argument is a string (name of the scope). In any case, they will return the scope they used.

# Scope nesting
To make service reusing easier, scopes can have parent scopes. In this case, the inject will not throw an error immediately if it doesn't have the required dependency, but will instead pass the request to the parent scope.

```typescript
const TOKEN = new InjectionToken<number>();

const rootScope = DefineModule([{
  initValue: 123,
  provider: TOKEN,
}], 'Root scope');

class ExampleServiceClass {
  public service = inject(TOKEN, this.scope);

  constructor(private scope?: ScopeToken) {}
}

const myScope = DefineModule([ExampleServiceClass], 'My new scope', rootScope);

const exampleService = inject(ExampleServiceClass, myScope); // OK
console.log(exampleService.service); // 123
const exampleService = inject(ExampleServiceClass, rootScope); // Injectables have to be provided in a module.
const valueService = inject(TOKEN, myScope); // OK
const valueService = inject(TOKEN, rootScope); // OK
```